### PR TITLE
Fixing an issue when cancelling

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -195,9 +195,9 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
   public void doOnCancel()
   {
-    if (callback != null) {
-        responseHelper.invokeCancel(callback);
-        callback = null;
+    if (this.callback != null) {
+        responseHelper.invokeCancel(this.callback);
+        this.callback = null;
     }
   }
 

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -46,6 +46,7 @@ import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 
 import com.facebook.react.modules.core.PermissionListener;
+import com.facebook.react.modules.core.PermissionAwareActivity;
 
 import static com.imagepicker.utils.MediaUtils.*;
 import static com.imagepicker.utils.MediaUtils.createNewFile;
@@ -594,6 +595,9 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
         {
           ((OnImagePickerPermissionsCallback) activity).setPermissionListener(listener);
           ActivityCompat.requestPermissions(activity, PERMISSIONS, requestCode);
+        }
+        else if (activity instanceof PermissionAwareActivity) {
+          ((PermissionAwareActivity) activity).requestPermissions(PERMISSIONS, requestCode, listener);
         }
         else
         {

--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -195,7 +195,10 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
 
   public void doOnCancel()
   {
-    responseHelper.invokeCancel(callback);
+    if (callback != null) {
+        responseHelper.invokeCancel(callback);
+        callback = null;
+    }
   }
 
   public void launchCamera()


### PR DESCRIPTION
There is an issue in this module where the user presses the cancel button twice, and on the second time the callback is NULL and this triggers an error. 

https://sentry.io/organizations/padlet-y9/issues/437400887/?project=256853&query=is%3Aunresolved+release%3Acom.wallwisher.Padlet-89.3&statsPeriod=14d

I implemented a fix found in this thread:

https://github.com/react-native-community/react-native-image-picker/issues/559#issuecomment-299125629