### PR TITLE
Fix raw urls

### DIFF
--- a/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
+++ b/android/src/main/java/com/imagepicker/utils/RealPathUtil.java
@@ -69,6 +69,13 @@ public class RealPathUtil {
 			// MediaProvider
 			else if (isMediaDocument(uri)) {
 				final String docId = DocumentsContract.getDocumentId(uri);
+
+				// Handle raw file urls differently, we can just return the current string minus
+				// the raw: prefix. https://github.com/Yalantis/uCrop/issues/318
+				if (id != null && id.startsWith("raw:")) {
+					return id.substring(4);
+				}
+
 				final String[] split = docId.split(":");
 				final String type = split[0];
 


### PR DESCRIPTION
Sometimes when loading urls from the Downloads directory we get back a string with a prefix `raw:` this is a fix to handle this (rare) occurrence take from https://github.com/Yalantis/uCrop/issues/318#issuecomment-333066640.

This is in response to these [issues](https://sentry.io/organizations/padlet-y9/issues/863517184/?project=256853&query=is%3Aunresolved+release%3Acom.wallwisher.Padlet-89.3&statsPeriod=14d).