### PR TITLE
Fixing dialog null reference crash

### DIFF
--- a/android/src/main/java/com/imagepicker/ImagePickerModule.java
+++ b/android/src/main/java/com/imagepicker/ImagePickerModule.java
@@ -580,7 +580,9 @@ public class ImagePickerModule extends ReactContextBaseJavaModule
                         innerActivity.startActivityForResult(intent, 1);
                       }
                     });
-            dialog.show();
+            if (dialog != null) {
+              dialog.show();
+            }
             return false;
           }
           responseHelper.invokeError(callback, "Permissions weren't granted");


### PR DESCRIPTION
Embrace: https://dash.embrace.io/app/mLKPR/v/126.0*127.0*128.0/session/hour/crash/eyJvcyI6ImEiLCJvc192YXJpYW50IjoiIiwiZnJhbWV3b3JrIjoxLCJ2IjoxLCJnaWQiOiJBMzMxODA0ODg4OTE1OTc3ODhGMkQ1MEFCRTM4M0Y1NCIsImJpZCI6IjQ2NEMzMzYxNUFFODRDMUFBODdGOUY1RTAwRDUzQzI2IiwibSI6ImNvbS5pbWFnZXBpY2tlci5JbWFnZVBpY2tlck1vZHVsZSQyLm9uUmVxdWVzdFBlcm1pc3Npb25zUmVzdWx0IiwidCI6ImphdmEubGFuZy5OdWxsUG9pbnRlckV4Y2VwdGlvbiIsImZpbGUiOiJJbWFnZVBpY2tlck1vZHVsZS5qYXZhIiwibCI6NTkzLCJiIjoiIn0=

Sentry: https://sentry.io/organizations/padlet-y9/issues/1957795476/?project=256853&query=is%3Aunresolved+release%3Acom.wallwisher.Padlet%40128.0%2B536&sort=user&statsPeriod=14d

Firebase: https://console.firebase.google.com/project/padlet-apps/crashlytics/app/android:com.wallwisher.Padlet/issues/a52687a2a430ae3805215bf6debbd26b?time=last-seven-days&versions=128.0%20(536)&sessionEventKey=5F8CFD9D002600016F8F8722B951BAE8_1463602918332363401